### PR TITLE
feat: add pr linter to github actions

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+    pull_request:
+        types:
+            - opened
+            - edited
+            - synchronize
+
+jobs:
+    main:
+        name: Validate PR title
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v4
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a linter task to ensure that all PR titles are valid and will trigger the proper releases (via semantic-release) based on conventional commit message format