### PR TITLE
feat: make package access public

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+access=public


### PR DESCRIPTION
Pipeline was failing due to semantic-release trying to publish the package as a private package. This PR adds config to the repo to ensure it is being published publicly